### PR TITLE
fix(ci): use pnpm exec instead of pnpx for vitest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Check pnpm-lock.yaml
         run: git diff --exit-code pnpm-lock.yaml
       - name: "Test"
-        run: pnpx vitest --coverage.enabled true
+        run: pnpm exec vitest --coverage.enabled true
       - name: "Report coverage"
         if: always()
         uses: davelosert/vitest-coverage-report-action@v2


### PR DESCRIPTION
## Summary
- Replace `pnpx vitest` with `pnpm exec vitest` in the test workflow.
- `pnpx` resolves via dlx and pulls the latest vitest (currently 4.x) at runtime, which is incompatible with the locally installed `@vitest/coverage-v8`. `pnpm exec` uses the version from `node_modules`, eliminating the version drift.

## Test plan
- [x] `pnpm install --frozen-lockfile && pnpm exec vitest --run --coverage.enabled true` passes locally
- [ ] CI test job passes